### PR TITLE
feature: add containerized execution method for most linux/macOS users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM vmware/powerclicore:latest
+
+# Add ESXi-Customizer-PS.ps1
+ADD https://raw.githubusercontent.com/VFrontDe/ESXi-Customizer-PS/master/ESXi-Customizer-PS.ps1 /usr/local/bin/ESXi-Customizer-PS.ps1
+
+ENTRYPOINT [ "/usr/bin/pwsh", "/usr/local/bin/ESXi-Customizer-PS.ps1", "-outDir", "/data" ]
+
+VOLUME [ "/data" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 ## Welcome to the ESXi-Customizer-PS GitHub Pages
 
 Full documentation is currently available at the [V-Front.de web site](https://esxi-customizer-ps.v-front.de) and will be gradually migrated to this location.
+
+## Run inside a container
+
+For users who don't want to install or are not familiar with `powershell`, in this example, we will use `Docker` as our container engine.
+
+1. Build the image
+
+    ```bash
+    # build and tag a new image using `./Dockerfile`
+    $ docker build -t esxi-customizer-ps .
+    ```
+
+2. Run (in this example, we make an alias to shorten the commandline)
+
+    ```bash
+    $ alias esxi-cps='docker run -it -v $(pwd):/data --rm esxi-customizer-ps'
+
+    # esxi-cps [options]
+    $ esxi-cps --help
+    ```


### PR DESCRIPTION
Hi @VFrontDe ,

Many thanks for your great work, this project helped me a lot!

Since I am not a windows user and not familiar with `powershell`, I hope the script can be executed on my linux machine without any knowledge of `pwsh` and `nuget`. 

Things turned out to be really easy, vmware provides containerized [vmware/powerclicore](https://hub.docker.com/r/vmware/powerclicore) and I can just mount the script and run `docker run -it -v $(pwd):/scripts --rm vmware/powerclicore /scripts/ESXi-Customizer-PS.ps1`. 

This way is much easier to get the script work for me, and in this pull request, I have added this method with a dockerfile which directly add the script from your github master branch (you may pin it to some release/commit in future), along with some related docs.

Maybe this is a bad idea to add a single file to a container image since it could be mounted from local filesystem, but at least this could ease life for someone :^)

Bad news: VMware.ImageBuilder is currently not working on `powershell` core, some work around may required, I am working on it.
